### PR TITLE
fix: corrigindo o ano de publicação

### DIFF
--- a/books/models.py
+++ b/books/models.py
@@ -1,13 +1,17 @@
 from django.db import models
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.contrib.auth import get_user_model
-
+import datetime
 
 User = get_user_model()
 
 class YearField(models.IntegerField):
     def __init__(self, *args, **kwargs):
-        kwargs['validators'] = [MinValueValidator(1000), MaxValueValidator(9999)]
+        current_year = datetime.date.today().year
+        kwargs['validators'] = [
+            MinValueValidator(1500),
+            MaxValueValidator(current_year)
+        ]
         kwargs['help_text'] = "Digite um ano (YYYY)"
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
## Contexto
Este PR corrige o campo do ano de publicação do model da app Books, adotando datas válidas e que fazem sentido.

## Alteração Proposta
- Adiciona uma variável `current_year` para definir o ano atual como valor máximo para o ano de publicação.

## Instruções para Revisão/Testes
Para testar as alterações:
1. Execute o servidor localmente.
2. Crie um empréstimo de um livro para um usuário, garantindo que a data de devolução esteja a um dia de distância.
3. Confirme se o e-mail de notificação é enviado para o usuário relacionado ao empréstimo.
4. Verifique se o conteúdo do e-mail reflete corretamente o aviso sobre a devolução iminente do livro.

## Observações Adicionais
- O código foi testado em ambiente local e os e-mails de notificação foram verificados.